### PR TITLE
fix order of compiler flags

### DIFF
--- a/easybuild/tools/toolchain/compiler.py
+++ b/easybuild/tools/toolchain/compiler.py
@@ -261,14 +261,14 @@ class Compiler(Toolchain):
 
         # precflags last
         for var in ['CFLAGS', 'CXXFLAGS']:
+            self.variables.join(var, 'OPTFLAGS', 'PRECFLAGS')
             self.variables.nextend(var, flags)
             self.variables.nextend(var, cflags)
-            self.variables.join(var, 'OPTFLAGS', 'PRECFLAGS')
 
         for var in ['FCFLAGS', 'FFLAGS', 'F90FLAGS']:
+            self.variables.join(var, 'OPTFLAGS', 'PRECFLAGS')
             self.variables.nextend(var, flags)
             self.variables.nextend(var, fflags)
-            self.variables.join(var, 'OPTFLAGS', 'PRECFLAGS')
 
     def _set_optimal_architecture(self):
         """ Get options for the current architecture """

--- a/test/framework/toolchain.py
+++ b/test/framework/toolchain.py
@@ -468,7 +468,7 @@ class ToolchainTest(EnhancedTestCase):
         tc.prepare()
 
         nvcc_flags = r' '.join([
-            r'-Xcompiler="-fopenmp -O2 -%s"' % tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch],
+            r'-Xcompiler="-O2 -%s -fopenmp"' % tc.COMPILER_OPTIMAL_ARCHITECTURE_OPTION[tc.arch],
             # the use of -lcudart in -Xlinker is a bit silly but hard to avoid
             r'-Xlinker=".* -lm -lrt -lcudart -lpthread"',
             r' '.join(["-gencode %s" % x for x in opts['cuda_gencode']]),
@@ -773,11 +773,11 @@ class ToolchainTest(EnhancedTestCase):
         init_config(build_options={'optarch': 'test'})
 
         tc_cflags = {
-            'CrayCCE': "-craype-verbose -homp -O2",
-            'CrayGNU': "-craype-verbose -fopenmp -O2",
-            'CrayIntel': "-craype-verbose -fopenmp -O2 -ftz -fp-speculation=safe -fp-model source",
-            'GCC': "-fopenmp -O2 -test",
-            'iccifort': "-fopenmp -O2 -test -ftz -fp-speculation=safe -fp-model source",
+            'CrayCCE': "-O2 -homp -craype-verbose",
+            'CrayGNU': "-O2 -fopenmp -craype-verbose",
+            'CrayIntel': "-O2 -ftz -fp-speculation=safe -fp-model source -fopenmp -craype-verbose",
+            'GCC': "-O2 -test -fopenmp",
+            'iccifort': "-O2 -test -ftz -fp-speculation=safe -fp-model source -fopenmp",
         }
 
         toolchains = [


### PR DESCRIPTION
to fix the broken tests in https://github.com/hpcugent/easybuild-framework/pull/1975

@akesandgren reordering things in `COMPILER_FLAGS` messed up the tests, also made sure that `-O2` (& co) are included first